### PR TITLE
CI: Add clang-format check and upload artifacts

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,23 +2,73 @@ name: CI Tests
 
 on:
   push:
-    branches: [ main ]
+    paths-ignore: ['**.md']
   pull_request:
-    branches: [ main ]
+    paths-ignore: ['**.md']
 
 jobs:
+  Clang_Format:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+        shell: bash
+      - name: Validate Source Formatting
+        run: |
+          find . -name '*.hh' -o -iname '*.cc' | xargs clang-format -i -style=file
+          if [[ -n $(git diff) ]]; then
+            echo "You must run make format before submitting a pull request"
+            echo ""
+            git diff
+            exit -1
+          fi
+        shell: bash
+
+  Release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libcurl4-gnutls-dev libboost-filesystem-dev ninja-build
+        shell: bash
+      - name: Validate Release Build
+        run: |
+          cd build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
+          ninja
+          ninja package
+          mkdir release && mv ./*.deb release
+        shell: bash
+      - name: Archive debian packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: libmspdb_release
+          path: build/release/*.deb
+
   Debug:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y cmake libcurl4-gnutls-dev libboost-filesystem-dev ninja-build
-      shell: bash
-    - name: Validate Debug Build
-      run: |
-        cd build
-        cmake -GNinja ..
-        ninja
-      shell: bash
+      - uses: actions/checkout@v2
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libcurl4-gnutls-dev libboost-filesystem-dev ninja-build
+        shell: bash
+      - name: Validate Debug Build
+        run: |
+          cd build
+          cmake -GNinja ..
+          ninja
+          ninja package
+          mkdir debug && mv *.deb debug/
+        shell: bash
+      - name: Archive debian packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: libmspdb_debug
+          path: build/debug/*.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ FILE(GLOB_RECURSE HEADERS ${PROJECT_SOURCE_DIR}/include/*.hh)
 ADD_SUBDIRECTORY(src)
 ADD_SUBDIRECTORY(tests)
 
+# Format target
+ADD_CUSTOM_TARGET(
+     format
+     COMMAND find ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/include -name '*.hh' -o -iname '*.cc' | xargs clang-format -i -style=file
+)
+
 # Install rule for include headers
 INSTALL(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include/mspdb COMPONENT libmspdb-dev)
 


### PR DESCRIPTION
This patch-set makes the following improvements to the CI:
- A clang-format check now prevents non-formatted code from passing
- The release and debug builds now upload their `deb` packages as artifacts

A convenient `make format` target was added as well to format source and header files with clang-format.