### PR TITLE
Upload version-less artifacts to Github releases and update readme

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -23,8 +23,8 @@ jobs:
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
           ninja
           ninja package
-          zip --verbose --junk-paths libmspdb-${{ github.ref_name }}.zip ./*.deb
-          ls -la libmspdb-${{ github.ref_name }}.zip
+          zip --verbose --junk-paths libmspdb.zip ./*.deb
+          ls -la libmspdb.zip
         shell: bash
       - name: Create Release
         id: create_release
@@ -43,6 +43,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/libmspdb-${{ github.ref_name }}.zip
-          asset_name: libmspdb-${{ github.ref_name }}.zip
+          asset_path: ./build/libmspdb.zip
+          asset_name: libmspdb.zip
           asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libmspdb
 
-## Description 
+## Description
 
 ![CI Tests](https://github.com/IntroVirt/libmspdb/actions/workflows/ccpp.yml/badge.svg)
 
@@ -8,23 +8,37 @@
 
 ## Quick Start
 
+### Install the latest release
+
+Pre-built debian packages can be downloaded and installed from the latest [libmspdb.zip](https://github.com/IntroVirt/libmspdb/releases/latest/download/libmspdb.zip) release. For example, with:
+```
+mkdir libmspdb_pkg && cd libmspdb_pkg
+wget https://github.com/IntroVirt/libmspdb/releases/latest/download/libmspdb.zip
+unzip libmspdb.zip
+sudo apt install ./*.deb
+```
+
+## Build and install from source
+
+To build from source:
 ```
 sudo apt-get -y cmake libcurl4-openssl-dev libboost-dev git
 git clone https://github.com/IntroVirt/libmspdb.git
 cd libmspdb/build/
 cmake ..
-make
-sudo make install
-```
-or to make a Debian package:
-```
-sudo apt-get -y ninja-build
-cd libmspdb/build/
-cmake -GNinja ..
-ninja
-ninja package
+make -j
 ```
 
+Debian packages can then be built and installed (recommended):
+```
+make package
+sudo apt install ./*.deb
+```
+
+Or `make` can be used directly to install:
+```
+sudo make install
+```
 
 ## Interested In Working For AIS?
 Check out our [Can You Hack It?®](https://www.canyouhackit.com) challenge and test your skills! Submit your score to show us what you’ve got. We have offices across the country and offer competitive pay and outstanding benefits. Join a team that is not only committed to the future of cyberspace, but to our employee’s success as well.


### PR DESCRIPTION
This patch set provides the following changes:
- Updates the CI to upload to Github releases an artifact in which the name doesn't include the version number.
- Updates the readme to add instructions for downloading and installing the pre-built debian packages from the automated releases. 

Closes #6