### PR TITLE
Typo in README. Other minor readme tweaks for readability and syntax …

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 ![CI Tests](https://github.com/IntroVirt/libmspdb/actions/workflows/ccpp.yml/badge.svg)
 
-**libmspdb** is a parsing library for Microsoft Program Database (PDB) files. This library is primarily used by [IntroVirt](https://github.com/IntroVirt/IntroVirt) to parse memory in Windows virtual machines. 
+**libmspdb** is a parsing library for Microsoft Program Database (PDB) files. This library is primarily used by [IntroVirt](https://github.com/IntroVirt/IntroVirt) to parse memory in Windows virtual machines.
 
 ## Quick Start
 
 ### Install the latest release
 
 Pre-built debian packages can be downloaded and installed from the latest [libmspdb.zip](https://github.com/IntroVirt/libmspdb/releases/latest/download/libmspdb.zip) release. For example, with:
-```
+
+```bash
 mkdir libmspdb_pkg && cd libmspdb_pkg
 wget https://github.com/IntroVirt/libmspdb/releases/latest/download/libmspdb.zip
 unzip libmspdb.zip
@@ -21,8 +22,9 @@ sudo apt install ./*.deb
 ## Build and install from source
 
 To build from source:
-```
-sudo apt-get -y cmake libcurl4-openssl-dev libboost-dev git
+
+```bash
+sudo apt-get install -y cmake libcurl4-openssl-dev libboost-dev git
 git clone https://github.com/IntroVirt/libmspdb.git
 cd libmspdb/build/
 cmake ..
@@ -30,17 +32,20 @@ make -j
 ```
 
 Debian packages can then be built and installed (recommended):
-```
+
+```bash
 make package
 sudo apt install ./*.deb
 ```
 
 Or `make` can be used directly to install:
-```
+
+```bash
 sudo make install
 ```
 
 ## Interested In Working For AIS?
+
 Check out our [Can You Hack It?®](https://www.canyouhackit.com) challenge and test your skills! Submit your score to show us what you’ve got. We have offices across the country and offer competitive pay and outstanding benefits. Join a team that is not only committed to the future of cyberspace, but to our employee’s success as well.
 
 <p align="center">


### PR DESCRIPTION
Mostly, I just fixed the dependency install line:

```bash
sudo apt-get -y cmake libcurl4-openssl-dev libboost-dev git
```

to be correct:

```bash
sudo apt-get install -y cmake libcurl4-openssl-dev libboost-dev git
```

Additionally, I marked the code blocks as bash for syntax highlighting and added some spacing that makes for better readability when viewing the file in a text editor.